### PR TITLE
Remove mem_limit and security_opt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,6 @@ services:
           - app:ro
         depends_on:
             - app
-        mem_limit: 64M
-        security_opt:
-            - no-new-privileges
         networks:
             - frontend
 
@@ -25,9 +22,6 @@ services:
             - rabbitmq
             - db
             - es1
-        mem_limit: 512M
-        security_opt:
-            - no-new-privileges
         networks:
             - frontend
             - backend
@@ -42,9 +36,6 @@ services:
           - MYSQL_DATABASE=${DATABASE_NAME}
         volumes:
             - db_data:/var/lib/mysql
-        mem_limit: 512M
-        security_opt:
-            - no-new-privileges
         networks:
             - backend
 
@@ -61,9 +52,6 @@ services:
                 hard: -1
         volumes:
             - es1_data:/usr/share/elasticsearch/data
-        mem_limit: 1500M
-        security_opt:
-            - no-new-privileges
         networks:
             - backend
 
@@ -81,9 +69,6 @@ services:
                 hard: -1
         volumes:
             - es2_data:/usr/share/elasticsearch/data
-        mem_limit: 1500M
-        security_opt:
-            - no-new-privileges
         networks:
             - backend
 
@@ -95,9 +80,6 @@ services:
             - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
         volumes:
             - rabbitmq_data:/var/lib/rabbitmq
-        mem_limit: 128M
-        security_opt:
-            - no-new-privileges
         networks:
             - backend
 
@@ -106,9 +88,6 @@ services:
         image: redis:4.0.8
         volumes:
             - redis_data:/data
-        mem_limit: 128M
-        security_opt:
-            - no-new-privileges
         networks:
             - backend
 


### PR DESCRIPTION
Remove options: `mem_limit` and `security_opt` from `docker-compose.yml` to avoid errors (must be set for a specific machine to securise containers).